### PR TITLE
Increase reliability of integration test

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -2,7 +2,7 @@ name: Integration test
 on: push
 jobs:
   integration-test:
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-20.04
 
     steps:

--- a/integration_test/authorisation/kustomization.yaml
+++ b/integration_test/authorisation/kustomization.yaml
@@ -22,6 +22,8 @@ patches:
     metadata:
       name: wso2is-populate
     spec:
+      # Sometimes WSO2 is painfully slow to start.
+      backoffLimit: 100
       template:
         spec:
           containers:


### PR DESCRIPTION
Because WSO2 sometimes takes a long time to start, this test can time
out. Increase the timeout and the job backoff limit to make the test
reliable, at the cost of accepting an increased runtime sometimes.